### PR TITLE
Feature review api

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,14 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { render } from 'react-dom';
-// import App from './app';
+import App from './app';
 import * as serviceWorker from './serviceWorker';
 import store from './redux/store';
 import './index.css';
-import ShowRestApi from './show-rest-api';
 
 render(
   <Provider store={store}>
-    <ShowRestApi>{/* <App /> */}</ShowRestApi>
+    <App />
   </Provider>,
   document.getElementById('root')
 );

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,15 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { render } from 'react-dom';
-import App from './app';
+// import App from './app';
 import * as serviceWorker from './serviceWorker';
 import store from './redux/store';
 import './index.css';
+import ShowRestApi from './show-rest-api';
 
 render(
   <Provider store={store}>
-    <App />
+    <ShowRestApi>{/* <App /> */}</ShowRestApi>
   </Provider>,
   document.getElementById('root')
 );

--- a/src/services/rest-api/access-rev-req-api.js
+++ b/src/services/rest-api/access-rev-req-api.js
@@ -16,6 +16,7 @@
 */
 
 import BaseApi from './base-api';
+import { stateList } from './constants';
 
 export default class AccessRevReqApi extends BaseApi {
   URL_USER = '/users/?githubId=';
@@ -32,24 +33,25 @@ export default class AccessRevReqApi extends BaseApi {
       return false;
     }
 
-    const searchRevReqId =
+    const searchRevReq =
       revReqId !== null
         ? await this.getResource(`${this.URL_REV_REQ}${revReqId}`)
         : null;
 
-    const revReq =
-      searchRevReqId !== null && searchRevReqId.length !== 0
-        ? this.arrToObj(searchRevReqId)
-        : null;
+    // If a review request ID exists and a review request was not found, exit with a negative check result.
+    if (searchRevReq !== null && searchRevReq.length === 0) {
+      return false;
+    }
+    
+    const revReq = searchRevReq !== null ? this.arrToObj(searchRevReq) : null;
 
-    const revReqState = revReq !== null ? revReq.state : 'CREATE';
+    const revReqState = revReq !== null ? revReq.state : stateList.CREATE;
     const revReqAuthor = revReq !== null ? revReq.author : githubId;
-
-    const user = this.arrToObj(searchUser);
-    const userRoles =
+    const currentUser = this.arrToObj(searchUser);
+    const allowedRoles =
       revReqAuthor === githubId
-        ? user.roles
-        : user.roles.filter((role) => role !== 'student');
+        ? currentUser.roles
+        : currentUser.roles.filter((role) => role !== 'student');
 
     const actionsData = await this.getResource(
       `${this.URL_ACCESS_REV_REQ_LIST}${revReqState}`
@@ -65,7 +67,7 @@ export default class AccessRevReqApi extends BaseApi {
 
     const actionList = this.arrToObj(actionMatch);
     const rolesForState = actionList.roles;
-    const isAccess = rolesForState.filter((role) => userRoles.includes(role));
+    const isAccess = rolesForState.filter((role) => allowedRoles.includes(role));
 
     return isAccess.length > 0;
   }

--- a/src/services/rest-api/access-review-api.js
+++ b/src/services/rest-api/access-review-api.js
@@ -30,7 +30,6 @@ export default class AccessReviewApi extends BaseApi {
     action,
     requestAuthor,
   }) => {
-    // let userRoles = null;
     switch (true) {
       // Если пользователь создающий ревью === автор ревью реквест, то список ролей обнуляется и никто не может редактировать
       case reviewState === stateList.CREATE:
@@ -39,13 +38,11 @@ export default class AccessReviewApi extends BaseApi {
       // Если пользователь выполняющий изменения не автор ревью, то список ролей обнуляется и никто не может редактировать
       case reviewState === stateList.DRAFT:
         return reviewAuthor === githubId ? currentUser.roles : [];
-      // break;
 
       // Если пользователь выполняющий изменения не автор ревью реквест, то список ролей обнуляется и никто не может редактировать
       case reviewState === stateList.PUBLISHED &&
         action === actionReviewList.PUBLISHED_TO_DISPUTED:
         return requestAuthor === githubId ? currentUser.roles : [];
-      // break;
 
       // Если пользователь выполняющий изменения не автор ревью реквест, то из списка ролей убирается роль student и author
       case reviewState === stateList.PUBLISHED &&
@@ -55,7 +52,6 @@ export default class AccessReviewApi extends BaseApi {
           : currentUser.roles.filter(
               (role) => ![rolesList.AUTHOR, rolesList.STUDENT].includes(role)
             );
-      // break;
 
       // Если пользователь выполняющий изменения не автор ревью или ревью реквест, то список ролей обнуляется и никто не может редактировать
       case reviewState === stateList.DISPUTED &&
@@ -63,7 +59,6 @@ export default class AccessReviewApi extends BaseApi {
         return requestAuthor === githubId || reviewAuthor === githubId
           ? currentUser.roles
           : [];
-      // break;
 
       // Если пользователь выполняющий изменения не автор ревью или ревью реквест, то из списка ролей удаляются author, student
       case reviewState === stateList.DISPUTED &&
@@ -73,18 +68,15 @@ export default class AccessReviewApi extends BaseApi {
           : currentUser.roles.filter(
               (role) => ![rolesList.AUTHOR, rolesList.STUDENT].includes(role)
             );
-      // break;
 
       // авторство не проверяется, отдается список ролей пользователя выполняющего изменения
       case reviewState === stateList.ACCEPTED:
       case reviewState === stateList.REJECTED:
         return currentUser.roles;
-      // break;
+
       default:
         return [];
-      // break;
     }
-    // return userRoles;
   };
 
   async onGetRevReg(requestId) {
@@ -124,11 +116,6 @@ export default class AccessReviewApi extends BaseApi {
       return false;
     }
 
-    /* const review =
-      searchReview !== null && searchReview.length !== 0
-        ? this.arrToObj(searchReview)
-        : null; */
-
     const review = searchReview !== null ? this.arrToObj(searchReview) : null;
 
     const reviewState = review !== null ? review.state : stateList.CREATE; // статус записи
@@ -147,9 +134,6 @@ export default class AccessReviewApi extends BaseApi {
     if (actionMatch.length === 0) {
       return false;
     }
-
-    // const requestId = review !== null ? review.requestId : null; // ссылка на запрос ревью
-    // const requestAuthor = requestId !== null ? await this.onSetRequestAuthor(requestId) : null;
 
     const requestAuthor = await this.onSetRequestAuthor(
       requestId || review.requestId

--- a/src/services/rest-api/access-review-api.js
+++ b/src/services/rest-api/access-review-api.js
@@ -95,14 +95,8 @@ export default class AccessReviewApi extends BaseApi {
     }
   };
 
-  async onGetRevReg(requestId) {
-    const result = await this.getResource(`${this.URL_REV_REQ}${requestId}`);
-
-    return result;
-  }
-
   async onSetRequestAuthor(requestId) {
-    const searchRevReq = await this.onGetRevReg(requestId);
+    const searchRevReq = await this.getResource(`${this.URL_REV_REQ}${requestId}`);
     const revReq = searchRevReq.length > 0 ? this.arrToObj(searchRevReq) : null;
     const requestAuthor = revReq !== null ? revReq.author : null;
 

--- a/src/services/rest-api/access-review-api.js
+++ b/src/services/rest-api/access-review-api.js
@@ -96,7 +96,9 @@ export default class AccessReviewApi extends BaseApi {
   };
 
   async onSetRequestAuthor(requestId) {
-    const searchRevReq = await this.getResource(`${this.URL_REV_REQ}${requestId}`);
+    const searchRevReq = await this.getResource(
+      `${this.URL_REV_REQ}${requestId}`
+    );
     const revReq = searchRevReq.length > 0 ? this.arrToObj(searchRevReq) : null;
     const requestAuthor = revReq !== null ? revReq.author : null;
 
@@ -128,9 +130,9 @@ export default class AccessReviewApi extends BaseApi {
 
     const review = searchReview !== null ? this.arrToObj(searchReview) : null;
 
-    const reviewState = review !== null ? review.state : stateList.CREATE; // статус записи
-    const reviewAuthor = review !== null ? review.author : githubId; // автор записи
-    const currentUser = this.arrToObj(searchUser); // юзер от имени которого делаются изменения
+    const reviewState = review !== null ? review.state : stateList.CREATE;
+    const reviewAuthor = review !== null ? review.author : githubId;
+    const currentUser = this.arrToObj(searchUser);
 
     // Проверка на возможные действия в текущем состоянии записи
     const actionsData = await this.getResource(

--- a/src/services/rest-api/access-review-api.js
+++ b/src/services/rest-api/access-review-api.js
@@ -1,0 +1,227 @@
+/* 
+  Класс отвечает за проверку прав пользователей для выполнения действий
+  с результатами проверки
+  Наследует класс BaseApi.
+
+  Используются следующие роли:
+  "student" - право создавать и редактировать проверки созданные этим пользователем
+  "supervisor" - право изменять статус запроса на проверку.
+
+  
+*/
+
+import BaseApi from './base-api';
+import { actionReviewList, rolesList, stateList } from './constants';
+
+export default class AccessReviewApi extends BaseApi {
+  URL_USER = '/users/?githubId=';
+
+  URL_REV = '/reviews/?id=';
+
+  URL_REV_REQ = '/reviewRequests/?id=';
+
+  URL_ACCESS_REV_LIST = '/accessRevlist/';
+
+  onSetUserRoles = ({
+    reviewState,
+    reviewAuthor,
+    githubId,
+    currentUser,
+    action,
+    requestAuthor,
+  }) => {
+    let userRoles = null;
+    switch (true) {
+      // Если пользователь выполняющий изменения не автор ревью, то список ролей обнуляется и никто не может редактировать
+      case reviewState === stateList.DRAFT:
+        userRoles = reviewAuthor === githubId ? currentUser.roles : [];
+        break;
+
+      // Если пользователь выполняющий изменения не автор ревью реквест, то список ролей обнуляется и никто не может редактировать
+      case reviewState === stateList.PUBLISHED &&
+        action === actionReviewList.PUBLISHED_TO_DISPUTED: // {
+        // const requestAuthor = await this.onSetRequestAuthor(requestId);
+        userRoles = requestAuthor === githubId ? currentUser.roles : [];
+        // };
+        break;
+
+      // Если пользователь выполняющий изменения не автор ревью реквест, то из списка ролей убирается роль student и author
+      case reviewState === stateList.PUBLISHED &&
+        action === actionReviewList.PUBLISHED_TO_ACCEPTED: // {
+        // const requestAuthor = await this.onSetRequestAuthor(requestId);
+        userRoles =
+          requestAuthor === githubId
+            ? currentUser.roles
+            : currentUser.roles.filter(
+                (role) => ![rolesList.AUTHOR, rolesList.STUDENT].includes(role)
+              );
+        // };
+        break;
+
+      // Если пользователь выполняющий изменения не автор ревью или ревью реквест, то список ролей обнуляется и никто не может редактировать
+      case reviewState === stateList.DISPUTED &&
+        action === actionReviewList.EDIT_REVIEW: // {
+        // const requestAuthor = await this.onSetRequestAuthor(requestId);
+        userRoles =
+          requestAuthor === githubId || reviewAuthor === githubId
+            ? currentUser.roles
+            : [];
+        // };
+        break;
+
+      // Если пользователь выполняющий изменения не автор ревью или ревью реквест, то из списка ролей удаляются author, student
+      case reviewState === stateList.DISPUTED &&
+        action === actionReviewList.DISPUTED_TO_ACCEPTED: // {
+        // const requestAuthor = await this.onSetRequestAuthor(requestId);
+        userRoles =
+          requestAuthor === githubId || reviewAuthor === githubId
+            ? currentUser.roles
+            : currentUser.roles.filter(
+                (role) => ![rolesList.AUTHOR, rolesList.STUDENT].includes(role)
+              );
+        // };
+        break;
+
+      // авторство не проверяется, отдается список ролей пользователя выполняющего изменения
+      case reviewState === stateList.ACCEPTED:
+      case reviewState === stateList.REJECTED:
+      case reviewState === stateList.CREATE:
+        userRoles = currentUser.roles;
+        break;
+      default:
+        userRoles = [];
+        break;
+    }
+    return userRoles;
+  };
+
+  async onGetRevReg(requestId) {
+    const result = await this.getResource(`${this.URL_REV_REQ}${requestId}`);
+
+    return result;
+  }
+
+  async onSetRequestAuthor(requestId) {
+    const searchRevReq = await this.onGetRevReg(requestId);
+    const revReq = searchRevReq.length > 0 ? this.arrToObj(searchRevReq) : null;
+    const requestAuthor = revReq !== null ? revReq.author : null;
+
+    return requestAuthor;
+  }
+
+  async userAccessRevCheck({ githubId, reviewId = null, action }) {
+    const searchUser = await this.getResource(`${this.URL_USER}${githubId}`); // ищем юзера от имени которого делаются изменения
+
+    // If the user is not found, exit with a negative check result
+    if (searchUser.length === 0) {
+      return false;
+    }
+
+    const searchReviewId =
+      reviewId !== null
+        ? await this.getResource(`${this.URL_REV}${reviewId}`)
+        : null;
+
+    const review =
+      searchReviewId !== null && searchReviewId.length !== 0
+        ? this.arrToObj(searchReviewId)
+        : null;
+
+    const reviewState = review !== null ? review.state : stateList.CREATE; // статус записи
+    const reviewAuthor = review !== null ? review.author : githubId; // автор записи
+    const requestId = review !== null ? review.requestId : null; // ссылка на запрос ревью
+
+    const currentUser = this.arrToObj(searchUser); // юзер от имени которого делаются изменения
+    // отсюда начинается новая логика
+
+    // Проверка на возможные действия в текущем состоянии записи
+    const actionsData = await this.getResource(
+      `${this.URL_ACCESS_REV_LIST}${reviewState}`
+    );
+    const actionMatch = actionsData.actionList.filter(
+      (item) => item.title === action
+    );
+
+    // If there are no available actions for the status of the entry, exit with a negative check result
+    if (actionMatch.length === 0) {
+      return false;
+    }
+
+    const requestAuthor =
+      requestId !== null ? await this.onSetRequestAuthor(requestId) : null;
+
+    const userRoles = this.onSetUserRoles({
+      reviewState,
+      reviewAuthor,
+      githubId,
+      currentUser,
+      action,
+      requestAuthor,
+    });
+
+    /* switch (true) {
+      // Если пользователь выполняющий изменения не автор ревью, то список ролей обнуляется и никто не может редактировать
+      case (reviewState === stateList.DRAFT): 
+        userRoles = reviewAuthor === githubId
+          ? currentUser.roles : [];
+        break;
+      
+        // Если пользователь выполняющий изменения не автор ревью реквест, то список ролей обнуляется и никто не может редактировать
+      case (
+        reviewState === stateList.PUBLISHED 
+        && action === actionReviewList.PUBLISHED_TO_DISPUTED
+      ): // {
+        // const requestAuthor = await this.onSetRequestAuthor(requestId);
+        userRoles = requestAuthor === githubId
+          ? currentUser.roles : [];
+      // };
+        break;
+      
+        // Если пользователь выполняющий изменения не автор ревью реквест, то из списка ролей убирается роль student и author
+      case (reviewState === stateList.PUBLISHED
+        && action === actionReviewList.PUBLISHED_TO_ACCEPTED
+      ): // {
+        // const requestAuthor = await this.onSetRequestAuthor(requestId);
+        userRoles = (requestAuthor === githubId)
+          ? currentUser.roles : currentUser.roles.filter((role) => ![rolesList.AUTHOR, rolesList.STUDENT].includes(role)); 
+      // };
+        break;
+      
+        // Если пользователь выполняющий изменения не автор ревью или ревью реквест, то список ролей обнуляется и никто не может редактировать
+      case (reviewState === stateList.DISPUTED
+        && action === actionReviewList.EDIT_REVIEW
+      ): // {
+        // const requestAuthor = await this.onSetRequestAuthor(requestId);
+        userRoles = (requestAuthor === githubId || reviewAuthor === githubId)
+          ? currentUser.roles : [];
+      // };
+        break;
+      
+        // Если пользователь выполняющий изменения не автор ревью или ревью реквест, то из списка ролей удаляются author, student
+      case (reviewState === stateList.DISPUTED
+        && action === actionReviewList.DISPUTED_TO_ACCEPTED
+      ): // {
+        // const requestAuthor = await this.onSetRequestAuthor(requestId);
+        userRoles = (requestAuthor === githubId || reviewAuthor === githubId)
+          ? currentUser.roles : currentUser.roles.filter((role) => ![rolesList.AUTHOR, rolesList.STUDENT].includes(role));
+      // };
+        break;
+      
+        // авторство не проверяется, отдается список ролей пользователя выполняющего изменения
+      case (reviewState === stateList.ACCEPTED):
+      case (reviewState === stateList.REJECTED):
+      case (reviewState === stateList.CREATE): 
+        userRoles = currentUser.roles;
+        break;  
+      default:
+        userRoles = [];
+        break;
+    }; */
+
+    const actionList = this.arrToObj(actionMatch);
+    const rolesForState = actionList.roles;
+    const isAccess = rolesForState.filter((role) => userRoles.includes(role));
+
+    return isAccess.length > 0;
+  }
+}

--- a/src/services/rest-api/access-review-api.js
+++ b/src/services/rest-api/access-review-api.js
@@ -3,10 +3,26 @@
   с результатами проверки
   Наследует класс BaseApi.
 
-  Используются следующие роли:
-  "student" - право создавать и редактировать проверки созданные этим пользователем
-  "supervisor" - право изменять статус запроса на проверку.
+  Используются следующие роли по статусам задачи:
+  
+  Cоздание, удаление, редактирование:
+  В статусе CREATE, DRAFT - "student", "author", "supervisor" - право создавать и редактировать проверки созданные этим пользователем
+  
+  Статус PUBLISHED:
+  Изменение статуса:
+  PUBLISHED_TO_DISPUTED - только пользователь с ролью "student" - автор review request 
+  PUBLISHED_TO_ACCEPTED - авторы review request или review,а также пользователь с ролью "supervisor" и системная учетная запись "systems" 
 
+  Cтатус DISPUTED:
+  Редактирование - только авторы review request или review
+  Изменение статуса: DISPUTED_TO_ACCEPTED - авторы review request или review,а также пользователь с ролью "supervisor" и системная учетная запись "systems"
+
+  Статус ACCEPTED: 
+  Изменение статуса: ACCEPTED_TO_REJECTED - только пользователь с ролью "supervisor"
+
+  Статус REJECTED:
+  Изменение статуса:
+  REJECTED_TO_ACCEPTED, REJECTED_TO_DISPUTED - только пользователь с ролью "supervisor"
   
 */
 

--- a/src/services/rest-api/constants.js
+++ b/src/services/rest-api/constants.js
@@ -1,3 +1,25 @@
+const rolesList = {
+  AUTHOR:
+    'author' /* право на создание, изменение, удаление tasks и review requests */,
+  STUDENT:
+    'student' /* право на создание, изменение, удаление review requests и review */,
+  SUPERVISOR:
+    'supervisor' /* право на изменения статусов, создание, изменение, удаление review */,
+  SYSTEMS:
+    'systems' /* системная учетная запись, право на изменение статусов */,
+};
+
+const stateList = {
+  CREATE: 'CREATE',
+  DRAFT: 'DRAFT',
+  PUBLISHED: 'PUBLISHED',
+  ARCHIVED: 'ARCHIVED',
+  COMPLETED: 'COMPLETED',
+  DISPUTED: 'DISPUTED',
+  ACCEPTED: 'ACCEPTED',
+  REJECTED: 'REJECTED',
+};
+
 const actionTaskList = {
   CREATE_TASK: 'CREATE_TASK',
   EDIT_TASK: 'EDIT_TASK',
@@ -58,6 +80,8 @@ const actionReviewList = {
 };
 
 export {
+  rolesList,
+  stateList,
   actionTaskList,
   actionRevReqList,
   actionCCSessionCheckList,

--- a/src/services/rest-api/constants.js
+++ b/src/services/rest-api/constants.js
@@ -2,29 +2,64 @@ const actionTaskList = {
   CREATE_TASK: 'CREATE_TASK',
   EDIT_TASK: 'EDIT_TASK',
   DELETE_TASK: 'DELETE_TASK',
-  DRAFT_TO_PUBLISHED: 'DRAFT_TO_PUBLISHED',
-  PUBLISHED_TO_DRAFT: 'PUBLISHED_TO_DRAFT',
-  PUBLISHED_TO_ARCHIVED: 'PUBLISHED_TO_ARCHIVED',
-  ARCHIVED_TO_PUBLISHED: 'ARCHIVED_TO_PUBLISHED',
+  DRAFT_TO_PUBLISHED:
+    'DRAFT_TO_PUBLISHED' /* опубликовано, видят пользователи, можно создать запрос на ревью и кросс-чек  */,
+  PUBLISHED_TO_DRAFT:
+    'PUBLISHED_TO_DRAFT' /* супервизор вернул на доработку, видит только автор */,
+  PUBLISHED_TO_ARCHIVED:
+    'PUBLISHED_TO_ARCHIVED' /* супервизор перевел задачу в архив, видят все, нельзя создать запрос на ревью и кросс-чек */,
+  ARCHIVED_TO_PUBLISHED:
+    'ARCHIVED_TO_PUBLISHED' /* супервизор вернул в опубликовано, можно создать запрос на ревью и кросс-чек */,
 };
 
 const actionRevReqList = {
   CREATE_REVREQ: 'CREATE_REVREQ',
   EDIT_REVREQ: 'EDIT_REVREQ',
   DELETE_REVREQ: 'DELETE_REVREQ',
-  DRAFT_TO_PUBLISHED: 'DRAFT_TO_PUBLISHED',
-  PUBLISHED_TO_DRAFT: 'PUBLISHED_TO_DRAFT',
-  PUBLISHED_TO_COMPLETED: 'PUBLISHED_TO_COMPLETED',
-  COMPLETED_TO_PUBLISHED: 'COMPLETED_TO_PUBLISHED',
+  DRAFT_TO_PUBLISHED:
+    'DRAFT_TO_PUBLISHED' /* опубликовано, видят пользователи, можно проводить ревью и кросс-чек сессии */,
+  PUBLISHED_TO_DRAFT:
+    'PUBLISHED_TO_DRAFT' /* супервизор вернул на доработку, видит только автор  */,
+  PUBLISHED_TO_COMPLETED:
+    'PUBLISHED_TO_COMPLETED' /* запрос на ревью помечен как выполненный, супервизором или системой */,
+  COMPLETED_TO_PUBLISHED:
+    'COMPLETED_TO_PUBLISHED' /* запрос на ревью вернули на опубликование супервизором */,
 };
 
 const actionCCSessionCheckList = {
   CREATE_CROSSCHECK: 'CREATE_CROSSCHECK',
   EDIT_CROSSCHECK: 'EDIT_CROSSCHECK',
   DELETE_CROSSCHECK: 'DELETE_CROSSCHECK',
-  DRAFT_TO_REQUESTS_GATHERING: 'DRAFT_TO_REQUESTS_GATHERING',
-  REQUESTS_GATHERING_TO_CROSS_CHECK: 'REQUESTS_GATHERING_TO_CROSS_CHECK',
-  CROSS_CHECK_TO_COMPLETED: 'CROSS_CHECK_TO_COMPLETED',
+  DRAFT_TO_REQUESTS_GATHERING:
+    'DRAFT_TO_REQUESTS_GATHERING' /* кросс-чек-сессия в стади сбора запросов на ревью */,
+  REQUESTS_GATHERING_TO_CROSS_CHECK:
+    'REQUESTS_GATHERING_TO_CROSS_CHECK' /* запросы собраны, пары распределены, кросс-чек-сессия в стадии ревью */,
+  CROSS_CHECK_TO_COMPLETED:
+    'CROSS_CHECK_TO_COMPLETED' /* кросс-чек-сессия закрыта */,
 };
 
-export { actionTaskList, actionRevReqList, actionCCSessionCheckList };
+const actionReviewList = {
+  CREATE_REVIEW: 'CREATE_REVIEW',
+  EDIT_REVIEW: 'EDIT_REVIEW',
+  DELETE_REVIEW: 'DELETE_REVIEW',
+  DRAFT_TO_PUBLISHED:
+    'DRAFT_TO_PUBLISHED' /* опубликовано, видит студент которого проверяют */,
+  PUBLISHED_TO_DISPUTED:
+    'PUBLISHED_TO_DISPUTED' /* студент отклонил оценку и оспаривает какой то пункт */,
+  PUBLISHED_TO_ACCEPTED: 'PUBLISHED_TO_ACCEPTED' /* студент принял оценку */,
+  DISPUTED_TO_ACCEPTED:
+    'DISPUTED_TO_ACCEPTED' /* проверяющий утвердил оценку */,
+  ACCEPTED_TO_REJECTED:
+    'ACCEPTED_TO_REJECTED' /* супервизор отклонил оценку, она не учитывается при подсчет финальной оценки */,
+  REJECTED_TO_ACCEPTED:
+    'REJECTED_TO_ACCEPTED' /* супервизор отменил отклонение, оценка учитывается в финальном подсчете */,
+  REJECTED_TO_DISPUTED:
+    'REJECTED_TO_DISPUTED' /* супервизор вернул оценку на пересмотр ревьювером */,
+};
+
+export {
+  actionTaskList,
+  actionRevReqList,
+  actionCCSessionCheckList,
+  actionReviewList,
+};

--- a/src/services/rest-api/cross-check-api.js
+++ b/src/services/rest-api/cross-check-api.js
@@ -74,7 +74,7 @@ export default class CCSessionApi extends AccessCCSessionApi {
       case 'CROSS_CHECK_TO_COMPLETED':
         return 'COMPLETED';
       default:
-        return 'CREATE';
+        return null;
     }
   };
 
@@ -248,6 +248,13 @@ export default class CCSessionApi extends AccessCCSessionApi {
     }
 
     const state = this.setState(requiredState);
+
+    if (state === null) {
+      return {
+        error: true,
+        message: `Unable to change status, unknown status "${state}" a cross-check-session "${ccSessionId}"`,
+      };
+    }
 
     const result = await this.patchResourse(`${this.URL_BASE}/${ccSessionId}`, {
       state,

--- a/src/services/rest-api/cross-check-api.js
+++ b/src/services/rest-api/cross-check-api.js
@@ -63,6 +63,8 @@ import { actionCCSessionCheckList } from './constants';
 export default class CCSessionApi extends AccessCCSessionApi {
   URL_BASE = '/crossCheckSessions';
 
+  URL_TASK = '/tasks';
+
   setState = (requiredState) => {
     switch (requiredState) {
       case 'DRAFT_TO_REQUESTS_GATHERING':
@@ -140,7 +142,7 @@ export default class CCSessionApi extends AccessCCSessionApi {
       };
     }
 
-    const taskCheck = await this.getResource(`/tasks/?id=${taskId}`);
+    const taskCheck = await this.getResource(`${this.URL_TASK}/?id=${taskId}`);
 
     if (taskCheck.length === 0) {
       return {

--- a/src/services/rest-api/cross-check-api.js
+++ b/src/services/rest-api/cross-check-api.js
@@ -63,7 +63,7 @@ import { actionCCSessionCheckList } from './constants';
 export default class CCSessionApi extends AccessCCSessionApi {
   URL_BASE = '/crossCheckSessions';
 
-  URL_TASK = '/tasks';
+  URL_TASK = '/tasks/?id=';
 
   setState = (requiredState) => {
     switch (requiredState) {
@@ -142,7 +142,7 @@ export default class CCSessionApi extends AccessCCSessionApi {
       };
     }
 
-    const taskCheck = await this.getResource(`${this.URL_TASK}/?id=${taskId}`);
+    const taskCheck = await this.getResource(`${this.URL_TASK}${taskId}`);
 
     if (taskCheck.length === 0) {
       return {

--- a/src/services/rest-api/cross-check-api.js
+++ b/src/services/rest-api/cross-check-api.js
@@ -11,6 +11,10 @@
   
   getCCSessionAttendees(ccSessionId) - выводит значение свойства attendees кросс-чек-сессии, требуется передача в аргументе id сессии,
     возвращает полные данные в виде массива объектов
+
+  async getCCSessionByStateNoDraft() - возвращает сессии в статусе отличном от статуса DRAFT
+
+  async getCCSessionByStateDraft() - возвращает сессии в статусе DRAFT
   
   createCCSession({ githubId, data }) - создание кросс-чек-сессии, аргументы метода передаются объектом!
     СТРУКТУРА объекта в параметре data:
@@ -84,6 +88,18 @@ export default class CCSessionApi extends AccessCCSessionApi {
     const ccSession = this.arrToObj(searchCCSession);
 
     return ccSession.attendees;
+  }
+
+  async getCCSessionByStateNoDraft() {
+    const result = await this.getResource(`${this.URL_BASE}/?state_ne=DRAFT`);
+
+    return result;
+  }
+
+  async getCCSessionByStateDraft() {
+    const result = await this.getResource(`${this.URL_BASE}/?state=DRAFT`);
+
+    return result;
   }
 
   async checkExistenceCCSession(ccSessionId) {

--- a/src/services/rest-api/cross-check-api.js
+++ b/src/services/rest-api/cross-check-api.js
@@ -117,12 +117,6 @@ export default class CCSessionApi extends AccessCCSessionApi {
     return result;
   }
 
-  async checkExistenceCCSession(ccSessionId) {
-    const isCCSession = await this.getCCSession(ccSessionId);
-
-    return isCCSession.length > 0;
-  }
-
   async createCCSession({ githubId, data }) {
     const { id = null, taskId = null } = data;
 
@@ -133,9 +127,9 @@ export default class CCSessionApi extends AccessCCSessionApi {
       };
     }
 
-    const ccSessionCheck = await this.checkExistenceCCSession(id);
+    const ccSessionCheck = await this.getCCSession(id);
 
-    if (ccSessionCheck) {
+    if (ccSessionCheck.length > 0) {
       return {
         error: true,
         message: `No creating possible. Found a cross-check-session with this id "${id}"`,
@@ -188,9 +182,7 @@ export default class CCSessionApi extends AccessCCSessionApi {
     return result;
   }
 
-  async editCCSession({ githubId, ccSessionId, data }) {
-    const ccSessionCheck = await this.checkExistenceCCSession(ccSessionId);
-
+  async editCCSession({ githubId, ccSessionId = null, data }) {
     if (!ccSessionCheck) {
       return {
         error: true,
@@ -222,11 +214,9 @@ export default class CCSessionApi extends AccessCCSessionApi {
 
   async toggleCCSessionState({
     githubId,
-    ccSessionId,
+    ccSessionId = null,
     requiredState /* enum DRAFT_TO_REQUESTS_GATHERING, REQUESTS_GATHERING_TO_CROSS_CHECK, CROSS_CHECK_TO_COMPLETED */,
   }) {
-    const ccSessionCheck = await this.checkExistenceCCSession(ccSessionId);
-
     if (!ccSessionCheck) {
       return {
         error: true,
@@ -263,9 +253,7 @@ export default class CCSessionApi extends AccessCCSessionApi {
     return result;
   }
 
-  async delCCSession({ githubId, ccSessionId }) {
-    const ccSessionCheck = await this.checkExistenceCCSession(ccSessionId);
-
+  async delCCSession({ githubId, ccSessionId =null }) {
     if (!ccSessionCheck) {
       return {
         error: true,

--- a/src/services/rest-api/cross-check-api.js
+++ b/src/services/rest-api/cross-check-api.js
@@ -26,7 +26,7 @@
       desiredReviewersAmount: 2, 
       attendees: []               // Обязательное поле! При создании Draf передается пустой массив
     }
-    при вызове метода проводятся проверки на уникальность id сессии, на пустое поле id и taskId, роли пользователя 
+    при вызове метода проводятся проверки на уникальность id сессии, taskId, на пустое поле id и taskId, роли пользователя 
 
   editCCSession({ githubId, ccSessionId, data }) - редактирование кросс-чек-сессии, редактируются только те поля которые переданны в data, 
     аргументы метода передаются объектом!
@@ -77,7 +77,7 @@ export default class CCSessionApi extends AccessCCSessionApi {
     if (searchCCSession.length === 0) {
       return {
         error: true,
-        message: `Can't show list of Attendees. No cross-check-session found with id ${ccSessionId}`,
+        message: `Can't show list of Attendees. No cross-check-session found with id "${ccSessionId}"`,
       };
     }
 
@@ -93,16 +93,30 @@ export default class CCSessionApi extends AccessCCSessionApi {
   }
 
   async createCCSession({ githubId, data }) {
-    const { id, taskId } = data;
+    const { id = null, taskId = null } = data;
 
-    if (!taskId) {
+    if (taskId === null) {
       return {
         error: true,
         message: `No creating possible. Property taskId not found!`,
       };
     }
 
-    if (!id) {
+    const taskCheck = await this.getResource(
+      `${this.URL_BASE}/?taskId=${taskId}`
+    );
+
+    if (taskCheck.length > 0) {
+      const session = this.arrToObj(taskCheck);
+      const { id: name, state } = session;
+
+      return {
+        error: true,
+        message: `Сreating a cross-check-session is impossible, for the task "${taskId}" there is already a cross-check-session name - "${name}" in the "${state}" status`,
+      };
+    }
+
+    if (id === null) {
       return {
         error: true,
         message: `No creating possible. Cross-check-session id not specified!`,
@@ -114,7 +128,7 @@ export default class CCSessionApi extends AccessCCSessionApi {
     if (ccSessionCheck) {
       return {
         error: true,
-        message: `No creating possible. Found a cross-check-session with this id ${id}`,
+        message: `No creating possible. Found a cross-check-session with this id "${id}"`,
       };
     }
 
@@ -127,7 +141,7 @@ export default class CCSessionApi extends AccessCCSessionApi {
     if (!accessCheck) {
       return {
         error: true,
-        message: `User ${githubId} does not have sufficient rights to create a cross-check-session`,
+        message: `User "${githubId}" does not have sufficient rights to create a cross-check-session`,
       };
     }
 
@@ -147,7 +161,7 @@ export default class CCSessionApi extends AccessCCSessionApi {
     if (!ccSessionCheck) {
       return {
         error: true,
-        message: `No editing possible. No cross-check-session found with id ${ccSessionId}`,
+        message: `No editing possible. No cross-check-session found with id "${ccSessionId}"`,
       };
     }
 
@@ -161,7 +175,7 @@ export default class CCSessionApi extends AccessCCSessionApi {
     if (!accessCheck) {
       return {
         error: true,
-        message: `User ${githubId} does not have sufficient rights to edit a cross-check-session`,
+        message: `User "${githubId}" does not have sufficient rights to edit a cross-check-session`,
       };
     }
 
@@ -183,7 +197,7 @@ export default class CCSessionApi extends AccessCCSessionApi {
     if (!ccSessionCheck) {
       return {
         error: true,
-        message: `No toggled status possible. No cross-check-session found with id ${ccSessionId}`,
+        message: `No toggled status possible. No cross-check-session found with id "${ccSessionId}"`,
       };
     }
 
@@ -213,7 +227,7 @@ export default class CCSessionApi extends AccessCCSessionApi {
     if (!accessCheck) {
       return {
         error: true,
-        message: `User ${githubId} does not have sufficient rights to toggled status a cross-check-session`,
+        message: `User "${githubId}" does not have sufficient rights to toggled status a cross-check-session`,
       };
     }
 
@@ -230,7 +244,7 @@ export default class CCSessionApi extends AccessCCSessionApi {
     if (!ccSessionCheck) {
       return {
         error: true,
-        message: `Unable to delete. No cross-check-session found with id ${ccSessionId}`,
+        message: `Unable to delete. No cross-check-session found with id "${ccSessionId}"`,
       };
     }
 
@@ -244,7 +258,7 @@ export default class CCSessionApi extends AccessCCSessionApi {
     if (!accessCheck) {
       return {
         error: true,
-        message: `User ${githubId} does not have sufficient rights to delete a cross-check-session`,
+        message: `User "${githubId}" does not have sufficient rights to delete a cross-check-session`,
       };
     }
 

--- a/src/services/rest-api/cross-check-api.js
+++ b/src/services/rest-api/cross-check-api.js
@@ -183,7 +183,7 @@ export default class CCSessionApi extends AccessCCSessionApi {
   }
 
   async editCCSession({ githubId, ccSessionId = null, data }) {
-    if (!ccSessionCheck) {
+    if (!ccSessionId) {
       return {
         error: true,
         message: `No editing possible. No cross-check-session found with id "${ccSessionId}"`,
@@ -217,7 +217,7 @@ export default class CCSessionApi extends AccessCCSessionApi {
     ccSessionId = null,
     requiredState /* enum DRAFT_TO_REQUESTS_GATHERING, REQUESTS_GATHERING_TO_CROSS_CHECK, CROSS_CHECK_TO_COMPLETED */,
   }) {
-    if (!ccSessionCheck) {
+    if (!ccSessionId) {
       return {
         error: true,
         message: `No toggled status possible. No cross-check-session found with id "${ccSessionId}"`,
@@ -253,8 +253,8 @@ export default class CCSessionApi extends AccessCCSessionApi {
     return result;
   }
 
-  async delCCSession({ githubId, ccSessionId =null }) {
-    if (!ccSessionCheck) {
+  async delCCSession({ githubId, ccSessionId = null }) {
+    if (!ccSessionId) {
       return {
         error: true,
         message: `Unable to delete. No cross-check-session found with id "${ccSessionId}"`,

--- a/src/services/rest-api/index.js
+++ b/src/services/rest-api/index.js
@@ -4,5 +4,14 @@ import TasksApi from './tasks-api';
 import ItemsTasksApi from './items-tasks-api';
 import RevReqApi from './rev-req-api';
 import CCSessionApi from './cross-check-api';
+import ReviewApi from './review-api';
 
-export { BaseApi, UserApi, TasksApi, ItemsTasksApi, RevReqApi, CCSessionApi };
+export {
+  BaseApi,
+  UserApi,
+  TasksApi,
+  ItemsTasksApi,
+  RevReqApi,
+  CCSessionApi,
+  ReviewApi,
+};

--- a/src/services/rest-api/items-tasks-api.js
+++ b/src/services/rest-api/items-tasks-api.js
@@ -36,7 +36,7 @@ export default class ItemsTasksApi extends TasksApi {
     if (searchTask.length === 0) {
       return {
         error: true,
-        message: `Can't show list of subtasks. No task found with id ${taskId}`,
+        message: `Can't show list of subtasks. No task found with id "${taskId}"`,
       };
     }
 
@@ -52,7 +52,7 @@ export default class ItemsTasksApi extends TasksApi {
     if (searchTask.length === 0) {
       return {
         error: true,
-        message: `Creation is impossible. No task found with id ${taskId}`,
+        message: `Creation is impossible. No task found with id "${taskId}"`,
       };
     }
 
@@ -67,7 +67,7 @@ export default class ItemsTasksApi extends TasksApi {
     if (!accessCheck) {
       return {
         error: true,
-        message: `User ${githubId} does not have sufficient rights to create items a task`,
+        message: `User "${githubId}" does not have sufficient rights to create items a task "${taskId}"`,
       };
     }
 
@@ -95,7 +95,7 @@ export default class ItemsTasksApi extends TasksApi {
     if (searchTask.length === 0) {
       return {
         error: true,
-        message: `No editing possible. No task found with id ${taskId}`,
+        message: `No editing possible. No task found with id "${taskId}"`,
       };
     }
 
@@ -110,7 +110,7 @@ export default class ItemsTasksApi extends TasksApi {
     if (!accessCheck) {
       return {
         error: true,
-        message: `User ${githubId} does not have sufficient rights to edit items a task`,
+        message: `User ${githubId} does not have sufficient rights to edit items a task "${taskId}"`,
       };
     }
 
@@ -119,7 +119,7 @@ export default class ItemsTasksApi extends TasksApi {
     if (oldTaskItems.filter((item) => item.id === data.id).length === 0) {
       return {
         error: true,
-        message: `No editing possible. No editable subtask id found`,
+        message: `No editing possible. No editable subtask a task "${taskId}" id found`,
       };
     }
 
@@ -145,7 +145,7 @@ export default class ItemsTasksApi extends TasksApi {
     if (searchTask.length === 0) {
       return {
         error: true,
-        message: `Unable to delete. No task found with id ${taskId}`,
+        message: `Unable to delete. No task found with id "${taskId}"`,
       };
     }
 
@@ -160,7 +160,7 @@ export default class ItemsTasksApi extends TasksApi {
     if (!accessCheck) {
       return {
         error: true,
-        message: `User ${githubId} does not have sufficient rights to delete items a task`,
+        message: `User ${githubId} does not have sufficient rights to delete items a task "${taskId}"`,
       };
     }
 
@@ -170,7 +170,7 @@ export default class ItemsTasksApi extends TasksApi {
     if (oldTaskItems.length === newTaskItems.length) {
       return {
         error: true,
-        message: `Unable to delete. No editable subtask id found`,
+        message: `Unable to delete. No editable subtask a task "${taskId}" id found`,
       };
     }
 

--- a/src/services/rest-api/items-tasks-api.js
+++ b/src/services/rest-api/items-tasks-api.js
@@ -46,6 +46,7 @@ export default class ItemsTasksApi extends TasksApi {
   }
 
   async createTaskItem({ githubId, taskId, data }) {
+    const { id: prefId } = data;
     const searchTask = await this.getTargetTask(taskId);
 
     if (searchTask.length === 0) {
@@ -71,8 +72,6 @@ export default class ItemsTasksApi extends TasksApi {
     }
 
     const lastItemId = this.createId();
-    const prefId = data.id;
-
     const newTaskItem = {
       ...data,
       id: `${prefId}${lastItemId}`,

--- a/src/services/rest-api/rev-req-api.js
+++ b/src/services/rest-api/rev-req-api.js
@@ -114,12 +114,6 @@ export default class RevReqApi extends AccessRevReqApi {
     return result;
   }
 
-  async checkExistenceRevReq(revReqId) {
-    const isRevReq = await this.getRevReq(revReqId);
-
-    return isRevReq.length > 0;
-  }
-
   async createRevReq({ githubId, data }) {
     const { task = null, id: prefId = 'rev-req-' } = data;
 
@@ -164,10 +158,8 @@ export default class RevReqApi extends AccessRevReqApi {
     return result;
   }
 
-  async editRevReq({ githubId, revReqId, data }) {
-    const revReqCheck = await this.checkExistenceRevReq(revReqId);
-
-    if (!revReqCheck) {
+  async editRevReq({ githubId, revReqId = null, data }) {
+    if (!revReqId) {
       return {
         error: true,
         message: `No editing possible. No review request found with id "${revReqId}"`,
@@ -198,12 +190,10 @@ export default class RevReqApi extends AccessRevReqApi {
 
   async toggleRevReqState({
     githubId,
-    revReqId,
+    revReqId = null,
     requiredState /* enum DRAFT_TO_PUBLISHED, PUBLISHED_TO_DRAFT, PUBLISHED_TO_COMPLETED, COMPLETED_TO_PUBLISHED */,
   }) {
-    const revReqCheck = await this.checkExistenceRevReq(revReqId);
-
-    if (!revReqCheck) {
+    if (!revReqId) {
       return {
         error: true,
         message: `No toggled status possible. No review request found with id "${revReqId}"`,
@@ -239,10 +229,8 @@ export default class RevReqApi extends AccessRevReqApi {
     return result;
   }
 
-  async delRevReq({ githubId, revReqId }) {
-    const revReqCheck = await this.checkExistenceRevReq(revReqId);
-
-    if (!revReqCheck) {
+  async delRevReq({ githubId, revReqId = null }) {
+    if (!revReqId) {
       return {
         error: true,
         message: `Unable to delete. No review request found with id "${revReqId}"`,

--- a/src/services/rest-api/rev-req-api.js
+++ b/src/services/rest-api/rev-req-api.js
@@ -57,6 +57,8 @@ import { actionRevReqList } from './constants';
 export default class RevReqApi extends AccessRevReqApi {
   URL_BASE = '/reviewRequests';
 
+  URL_TASK = '/tasks';
+
   setState = (requiredState) => {
     switch (requiredState) {
       case 'DRAFT_TO_PUBLISHED':
@@ -119,7 +121,7 @@ export default class RevReqApi extends AccessRevReqApi {
   }
 
   async createRevReq({ githubId, data }) {
-    const { task = null } = data;
+    const { task = null, id: prefId = 'rev-req-' } = data;
 
     if (!task) {
       return {
@@ -128,7 +130,7 @@ export default class RevReqApi extends AccessRevReqApi {
       };
     }
 
-    const taskCheck = await this.getResource(`${this.URL_BASE}/?task=${task}`);
+    const taskCheck = await this.getResource(`${this.URL_TASK}/?id=${task}`);
 
     if (taskCheck.length === 0) {
       return {
@@ -151,7 +153,6 @@ export default class RevReqApi extends AccessRevReqApi {
     }
 
     const lastTaskId = this.createId();
-    const prefId = data.id;
     const newRevReq = {
       ...data,
       id: `${prefId}${lastTaskId}`,

--- a/src/services/rest-api/rev-req-api.js
+++ b/src/services/rest-api/rev-req-api.js
@@ -94,6 +94,12 @@ export default class RevReqApi extends AccessRevReqApi {
     return result;
   }
 
+  async getRevReqByTask(taskId) {
+    const result = await this.getResource(`${this.URL_BASE}/?task=${taskId}`);
+
+    return result;
+  }
+
   async getRevReqByStateNoDraft() {
     const result = await this.getResource(`${this.URL_BASE}/?state_ne=DRAFT`);
 

--- a/src/services/rest-api/rev-req-api.js
+++ b/src/services/rest-api/rev-req-api.js
@@ -73,12 +73,6 @@ export default class RevReqApi extends AccessRevReqApi {
     return result;
   }
 
-  async getRevReqByTask(taskId) {
-    const result = await this.getResource(`${this.URL_BASE}/?task=${taskId}`);
-
-    return result;
-  }
-
   async getRevReqByCrossCheckId(crossCheckSessionId) {
     const result = await this.getResource(
       `${this.URL_BASE}/?crossCheckSessionId=${crossCheckSessionId}`

--- a/src/services/rest-api/rev-req-api.js
+++ b/src/services/rest-api/rev-req-api.js
@@ -70,7 +70,7 @@ export default class RevReqApi extends AccessRevReqApi {
       case 'COMPLETED_TO_PUBLISHED':
         return 'PUBLISHED';
       default:
-        return 'CREATE';
+        return null;
     }
   };
 
@@ -224,6 +224,13 @@ export default class RevReqApi extends AccessRevReqApi {
     }
 
     const state = this.setState(requiredState);
+
+    if (state === null) {
+      return {
+        error: true,
+        message: `Unable to change status, unknown status "${state}" a review request "${revReqId}"`,
+      };
+    }
 
     const result = await this.patchResourse(`${this.URL_BASE}/${revReqId}`, {
       state,

--- a/src/services/rest-api/rev-req-api.js
+++ b/src/services/rest-api/rev-req-api.js
@@ -57,7 +57,7 @@ import { actionRevReqList } from './constants';
 export default class RevReqApi extends AccessRevReqApi {
   URL_BASE = '/reviewRequests';
 
-  URL_TASK = '/tasks';
+  URL_TASK = '/tasks/?id=';
 
   setState = (requiredState) => {
     switch (requiredState) {
@@ -130,7 +130,7 @@ export default class RevReqApi extends AccessRevReqApi {
       };
     }
 
-    const taskCheck = await this.getResource(`${this.URL_TASK}/?id=${task}`);
+    const taskCheck = await this.getResource(`${this.URL_TASK}${task}`);
 
     if (taskCheck.length === 0) {
       return {

--- a/src/services/rest-api/rev-req-api.js
+++ b/src/services/rest-api/rev-req-api.js
@@ -14,6 +14,10 @@
 
   getRevReqByCrossCheckId(crossCheckSessionId) - выводит все запросы на ревью созданные в рамках кросс-чек-сессии,
   требуется передача в аргументе поля crossCheckSessionId, возвращает полные данные в виде массива объектов
+
+  async getRevReqByStateNoDraft() - выводит все запросы на ревью в статусе отличном от DRAFT
+
+  async getRevReqByStateDraft() - выводит все запросы на ревью в статусе DRAFT 
   
   createRevReq({ githubId, data }) - создание запроса на ревью, аргументы метода передаются объектом!
     СТРУКТУРА объекта в параметре data:
@@ -69,6 +73,18 @@ export default class RevReqApi extends AccessRevReqApi {
     const result = await this.getResource(
       `${this.URL_BASE}/?author=${nameAuthor}`
     );
+
+    return result;
+  }
+
+  async getRevReqByStateNoDraft() {
+    const result = await this.getResource(`${this.URL_BASE}/?state_ne=DRAFT`);
+
+    return result;
+  }
+
+  async getRevReqByStateDraft() {
+    const result = await this.getResource(`${this.URL_BASE}/?state=DRAFT`);
 
     return result;
   }

--- a/src/services/rest-api/review-api.js
+++ b/src/services/rest-api/review-api.js
@@ -1,0 +1,255 @@
+/* 
+  Класс для работы с сущностью Tasks 
+  Наследует класс AccessReviewApi.
+  Требуется импорт actionReviewList из constants.js
+  
+  *****
+  Доступные методы:
+  getRevReqAll() - выводит все запросы на ревью, возвращает полные данные в виде массива объектов
+  
+  getRevReq(id) -  выводит запрос на ревью по id, возвращает полные данные в виде массива c одним объектом
+  
+  getRevReqByAuthor(nameAuthor) - выводит все запросы на ревью созданные автором, требуется передача в аргументе поля author,
+    возвращает полные данные в виде массива объектов
+
+  getRevReqByCrossCheckId(crossCheckSessionId) - выводит все запросы на ревью созданные в рамках кросс-чек-сессии,
+  требуется передача в аргументе поля crossCheckSessionId, возвращает полные данные в виде массива объектов
+  
+  createRevReq({ githubId, data }) - создание запроса на ревью, аргументы метода передаются объектом!
+    СТРУКТУРА объекта в параметре data:
+    {
+      id: "rev-req-", // префикс id 
+      crossCheckSessionId: null, // or id cross-check-session for example "rss2020Q3react-xcheck"
+      author: githubId, // пользователь Внимание! Обязательное поле!
+      task: taskId, // id задачи Внимание! Обязательное поле!
+      url_pr: 'https://github...', // ссылка на пулл реквест
+      url_deploy: 'https://app...', // ссылка на деплой
+      selfGrade: { // в этот объект передаются id пунктов задачи, самооценка и коментарий студента
+        basic_p1: {score: 20, comment: "Well done!"},
+        extra_p1: {score: 15, comment: "Some things are done, some are not"},
+        fines_p1: {score: 0, comment: "No ticket today"},
+      }
+    }
+
+  editRevReq({ githubId, revReqId, data }) - редактирование запроса на ревью, редактируются только те поля которые переданны в data, 
+    аргументы метода передаются объектом!
+
+  delRevReq({ githubId, revReqId }) - удаление запроса на ревью, удаляется полностью, аргументы метода передаются объектом!
+  
+  toggleRevReqState({
+    githubId,     // пользователь 
+    revReqId,       // id задачи
+    requiredState // enum DRAFT_TO_PUBLISHED, PUBLISHED_TO_DRAFT, PUBLISHED_TO_COMPLETED, COMPLETED_TO_PUBLISHED 
+  }) - переключение статуса запроса на ревью DRAFT, PUBLISHED, COMPLETED,
+    Аргумент requiredState формализован и можем принимать только перечисленные значения. 
+
+  Последние 4 метода возвращают объект идентичный переданному в случае успеха, или сообщение об ошибке.
+  Формат сообщения - объект вида {error: true, message: 'text ...'}
+*/
+
+import AccessReviewApi from './access-review-api';
+import { actionReviewList } from './constants';
+
+export default class ReviewApi extends AccessReviewApi {
+  URL_BASE = '/reviews';
+
+  URL_REQ = '/reviewRequests';
+
+  setState = (requiredState) => {
+    switch (requiredState) {
+      case 'DRAFT_TO_PUBLISHED':
+        return 'PUBLISHED';
+      case 'PUBLISHED_TO_ACCEPTED':
+        return 'ACCEPTED';
+      case 'PUBLISHED_TO_DISPUTED':
+        return 'DISPUTED';
+      case 'DISPUTED_TO_ACCEPTED':
+        return 'ACCEPTED';
+      case 'ACCEPTED_TO_REJECTED':
+        return 'REJECTED';
+      case 'REJECTED_TO_DISPUTED':
+        return 'DISPUTED';
+      case 'REJECTED_TO_ACCEPTED':
+        return 'ACCEPTED';
+      default:
+        return 'CREATE';
+    }
+  };
+
+  async getReviewAll() {
+    const result = await this.getResource(this.URL_BASE);
+
+    return result;
+  }
+
+  async getReview(id) {
+    const result = await this.getResource(`${this.URL_BASE}/?id=${id}`);
+
+    return result;
+  }
+
+  async getReviewByAuthor(nameAuthor) {
+    const result = await this.getResource(
+      `${this.URL_BASE}/?author=${nameAuthor}`
+    );
+
+    return result;
+  }
+
+  async getReviewByRequest(revReqId) {
+    const result = await this.getResource(
+      `${this.URL_BASE}/?requestId=${revReqId}`
+    );
+
+    return result;
+  }
+
+  async checkExistenceReview(reviewId) {
+    const isReview = await this.getReview(reviewId);
+
+    return isReview.length > 0;
+  }
+
+  async createReview({ githubId, data }) {
+    const { requestId = null, id: prefId = 'rev-id-' } = data;
+
+    if (!requestId) {
+      return {
+        error: true,
+        message: `No creating possible. Property requestId not found!`,
+      };
+    }
+
+    const requestCheck = await this.getResource(
+      `${this.URL_REQ}/?id=${requestId}`
+    );
+
+    if (requestCheck.length === 0) {
+      return {
+        error: true,
+        message: `No creating possible. Review request "${requestCheck}" not found!`,
+      };
+    }
+
+    const action = actionReviewList.CREATE_REVIEW;
+    const accessCheck = await this.userAccessRevCheck({
+      githubId,
+      action,
+    });
+
+    if (!accessCheck) {
+      return {
+        error: true,
+        message: `User "${githubId}" does not have sufficient rights to create a review`,
+      };
+    }
+
+    const lastTaskId = this.createId();
+    const newReview = {
+      ...data,
+      id: `${prefId}${lastTaskId}`,
+      state: 'DRAFT',
+    };
+
+    const result = await this.sendResource(this.URL_BASE, newReview);
+
+    return result;
+  }
+
+  async editReview({ githubId, reviewId, data }) {
+    const reviewCheck = await this.checkExistenceReview(reviewId);
+
+    if (!reviewCheck) {
+      return {
+        error: true,
+        message: `No editing possible. No review found with id "${reviewId}"`,
+      };
+    }
+
+    const action = actionReviewList.EDIT_REVIEW;
+    const accessCheck = await this.userAccessRevCheck({
+      githubId,
+      reviewId,
+      action,
+    });
+
+    if (!accessCheck) {
+      return {
+        error: true,
+        message: `User "${githubId}" does not have sufficient rights to edit a review "${reviewId}"`,
+      };
+    }
+
+    const result = await this.patchResourse(
+      `${this.URL_BASE}/${reviewId}`,
+      data
+    );
+
+    return result;
+  }
+
+  async toggleReviewState({
+    githubId,
+    reviewId,
+    requiredState /* enum DRAFT_TO_PUBLISHED, PUBLISHED_TO_ACCEPTED, PUBLISHED_TO_DISPUTED, DISPUTED_TO_ACCEPTED, ACCEPTED_TO_REJECTED, REJECTED_TO_DISPUTED, REJECTED_TO_ACCEPTED */,
+  }) {
+    const reviewCheck = await this.checkExistenceReview(reviewId);
+
+    if (!reviewCheck) {
+      return {
+        error: true,
+        message: `No toggled status possible. No review found with id "${reviewId}"`,
+      };
+    }
+
+    const accessCheck = await this.userAccessRevCheck({
+      githubId,
+      reviewId,
+      action: requiredState,
+    });
+
+    if (!accessCheck) {
+      return {
+        error: true,
+        message: `User "${githubId}" does not have sufficient rights to toggled status a review "${reviewId}"`,
+      };
+    }
+
+    const state = this.setState(requiredState);
+
+    const result = await this.patchResourse(`${this.URL_BASE}/${reviewId}`, {
+      state,
+    });
+
+    return result;
+  }
+
+  async delReview({ githubId, reviewId }) {
+    const reviewCheck = await this.checkExistenceReview(reviewId);
+
+    if (!reviewCheck) {
+      return {
+        error: true,
+        message: `Unable to delete. No review found with id "${reviewId}"`,
+      };
+    }
+
+    const action = actionReviewList.DELETE_REVIEW;
+    const accessCheck = await this.userAccessRevCheck({
+      githubId,
+      reviewId,
+      action,
+    });
+
+    if (!accessCheck) {
+      return {
+        error: true,
+        message: `User "${githubId}" does not have sufficient rights to delete a review "${reviewId}"`,
+      };
+    }
+
+    const result = await this.delResourse(`${this.URL_BASE}/${reviewId}`);
+
+    return result;
+  }
+}

--- a/src/services/rest-api/review-api.js
+++ b/src/services/rest-api/review-api.js
@@ -129,6 +129,18 @@ export default class ReviewApi extends AccessReviewApi {
     return request.selfGrade;
   }
 
+  async getReviewByStateNoDraft() {
+    const result = await this.getResource(`${this.URL_BASE}/?state_ne=DRAFT`);
+
+    return result;
+  }
+
+  async getReviewByStateDraft() {
+    const result = await this.getResource(`${this.URL_BASE}/?state=DRAFT`);
+
+    return result;
+  }
+
   async createReview({ githubId, data }) {
     const { requestId = null, id: prefId = 'rev-id-' } = data;
 

--- a/src/services/rest-api/review-api.js
+++ b/src/services/rest-api/review-api.js
@@ -17,6 +17,10 @@
   
   async getSelfGradeRequest(requestId) - выводит объект selfGrade из запроса на ревью, нужен для 
     копирования самооценки selfGrade в оценку grade ревью
+
+  async getReviewByStateNoDraft() - вызов метода возвращает список ревью в статусе DRAFT
+
+  async getReviewByStateDraft() - вызов метода возвращает список ревью в статусе отличном от DRAFT 
   
   createReview({ githubId, data }) - создание ревью, аргументы метода передаются объектом!
     СТРУКТУРА объекта в параметре data:

--- a/src/services/rest-api/tasks-api.js
+++ b/src/services/rest-api/tasks-api.js
@@ -114,6 +114,7 @@ export default class TasksApi extends AccessTasksApi {
   }
 
   async createTaskHeader({ githubId, data }) {
+    const { id: prefId = 'simple-task-' } = data;
     const action = actionTaskList.CREATE_TASK;
     const accessCheck = await this.userAccessTasksCheck({
       githubId,
@@ -128,7 +129,6 @@ export default class TasksApi extends AccessTasksApi {
     }
 
     const lastTaskId = this.createId();
-    const prefId = data.id;
     const newTaskHeader = {
       ...data,
       id: `${prefId}${lastTaskId}`,

--- a/src/services/rest-api/tasks-api.js
+++ b/src/services/rest-api/tasks-api.js
@@ -6,9 +6,16 @@
   *****
   Доступные методы:
   getTasksAll() - выводит все задачи, возвращает полные данные в виде массива объектов
+  
   getTask(id) -  выводит задачу по id, возвращает полные данные в виде массива c одним объектом
+  
   getTaskByAuthor(nameAuthor) - выводит все задачи созданные автором, требуется передача в аргументе поля author,
     возвращает полные данные в виде массива объектов
+
+  async getTaskByStateNoDraft() - возвращает задачи в статусе отличном от статуса DRAFT
+
+  async getTaskByStateDraft() - возвращает задачи в статусе DRAFT
+
   createTaskHeader({ githubId, data }) - создание карточки задачи, можно создавать как заголовок задачи, 
     тогда необходимо в объект data поля заголовка задачи и передавать пустой массив items: []
     {
@@ -28,12 +35,15 @@
       ] 
     }
     аргументы метода передаются объектом!
-  editTaskHeader({ githubId, taskId, data }) - редактирование карточки задачи, редактируются только те поля которые переданы в объект data,
+  
+    editTaskHeader({ githubId, taskId, data }) - редактирование карточки задачи, редактируются только те поля которые переданы в объект data,
     если для редактирования items пользуются этим методом, то массив items нужно передавать полностью, т.е. не только изменяемую запись, 
     но и все записи которые там были. Для удаления всех items, можно передать объект дата с пустым массивом {items: []} 
     аргументы метода передаются объектом!
-  delTask({ githubId, taskId }) - удаление задачи, удаляется полностью, аргументы метода передаются объектом!
-  toggleTaskState({
+  
+    delTask({ githubId, taskId }) - удаление задачи, удаляется полностью, аргументы метода передаются объектом!
+  
+    toggleTaskState({
     githubId,     // пользователь 
     taskId,       // id задачи
     requiredState // enum DRAFT_TO_PUBLISHED, PUBLISHED_TO_DRAFT, PUBLISHED_TO_ARCHIVED, ARCHIVED_TO_PUBLISHED 
@@ -66,6 +76,18 @@ export default class TasksApi extends AccessTasksApi {
     const result = await this.getResource(
       `${this.URL_BASE}/?author=${nameAuthor}`
     );
+
+    return result;
+  }
+
+  async getTaskByStateNoDraft() {
+    const result = await this.getResource(`${this.URL_BASE}/?state_ne=DRAFT`);
+
+    return result;
+  }
+
+  async getTaskByStateDraft() {
+    const result = await this.getResource(`${this.URL_BASE}/?state=DRAFT`);
 
     return result;
   }

--- a/src/services/rest-api/tasks-api.js
+++ b/src/services/rest-api/tasks-api.js
@@ -107,12 +107,6 @@ export default class TasksApi extends AccessTasksApi {
     return result;
   }
 
-  async checkExistenceTask(taskId) {
-    const isTask = await this.getTask(taskId);
-
-    return isTask.length > 0;
-  }
-
   async createTaskHeader({ githubId, data }) {
     const { id: prefId = 'simple-task-' } = data;
     const action = actionTaskList.CREATE_TASK;
@@ -142,13 +136,11 @@ export default class TasksApi extends AccessTasksApi {
   }
 
   // Cannot edit "state", "author" property, "state", "author" property is read-only
-  async editTaskHeader({ githubId, taskId, data }) {
-    const taskCheck = await this.checkExistenceTask(taskId);
-
-    if (!taskCheck) {
+  async editTaskHeader({ githubId, taskId = null, data }) {
+    if (!taskId) {
       return {
         error: true,
-        message: `No editing possible. No task found with id ${taskId}`,
+        message: `No editing possible. No task found with id "${taskId}"`,
       };
     }
 
@@ -172,22 +164,17 @@ export default class TasksApi extends AccessTasksApi {
   }
 
   /* 
-    Нужна еше проверка на статус записи, невозможно перепрыгнуть через уровень
-    Или реализовать это на клиенте, показывать возможный переход на статус.
     Аргумент requiredState формализован и можем принимать только перечисленные значения,
-
   */
   async toggleTaskState({
     githubId,
-    taskId,
+    taskId = null,
     requiredState /* enum DRAFT_TO_PUBLISHED, PUBLISHED_TO_DRAFT, PUBLISHED_TO_ARCHIVED, ARCHIVED_TO_PUBLISHED */,
   }) {
-    const taskCheck = await this.checkExistenceTask(taskId);
-
-    if (!taskCheck) {
+    if (!taskId) {
       return {
         error: true,
-        message: `No editing possible. No task found with id ${taskId}`,
+        message: `No editing possible. No task found with id "${taskId}"`,
       };
     }
 
@@ -220,13 +207,11 @@ export default class TasksApi extends AccessTasksApi {
     return result;
   }
 
-  async delTask({ githubId, taskId }) {
-    const taskCheck = await this.checkExistenceTask(taskId);
-
-    if (!taskCheck) {
+  async delTask({ githubId, taskId = null }) {
+    if (!taskId) {
       return {
         error: true,
-        message: `Unable to delete. No task found with id ${taskId}`,
+        message: `Unable to delete. No task found with id "${taskId}"`,
       };
     }
 

--- a/src/services/rest-api/tasks-api.js
+++ b/src/services/rest-api/tasks-api.js
@@ -60,6 +60,21 @@ import { actionTaskList } from './constants';
 export default class TasksApi extends AccessTasksApi {
   URL_BASE = '/tasks';
 
+  setState = (requiredState) => {
+    switch (requiredState) {
+      case 'DRAFT_TO_PUBLISHED':
+        return 'PUBLISHED';
+      case 'PUBLISHED_TO_DRAFT':
+        return 'DRAFT';
+      case 'PUBLISHED_TO_ARCHIVED':
+        return 'ARCHIVED';
+      case 'ARCHIVED_TO_PUBLISHED':
+        return 'PUBLISHED';
+      default:
+        return 'CREATE';
+    }
+  };
+
   async getTasksAll() {
     const result = await this.getResource(this.URL_BASE);
 
@@ -176,30 +191,10 @@ export default class TasksApi extends AccessTasksApi {
       };
     }
 
-    const action = requiredState;
-    let state = null;
-
-    switch (requiredState) {
-      case 'DRAFT_TO_PUBLISHED':
-        state = 'PUBLISHED';
-        break;
-      case 'PUBLISHED_TO_DRAFT':
-        state = 'DRAFT';
-        break;
-      case 'PUBLISHED_TO_ARCHIVED':
-        state = 'ARCHIVED';
-        break;
-      case 'ARCHIVED_TO_PUBLISHED':
-        state = 'PUBLISHED';
-        break;
-      default:
-        break;
-    }
-
     const accessCheck = await this.userAccessTasksCheck({
       githubId,
       taskId,
-      action,
+      action: requiredState,
     });
 
     if (!accessCheck) {
@@ -208,6 +203,8 @@ export default class TasksApi extends AccessTasksApi {
         message: `User ${githubId} does not have sufficient rights to toggled status a task`,
       };
     }
+
+    const state = this.setState(requiredState);
 
     const result = await this.patchResourse(`${this.URL_BASE}/${taskId}`, {
       state,

--- a/src/services/rest-api/tasks-api.js
+++ b/src/services/rest-api/tasks-api.js
@@ -71,7 +71,7 @@ export default class TasksApi extends AccessTasksApi {
       case 'ARCHIVED_TO_PUBLISHED':
         return 'PUBLISHED';
       default:
-        return 'CREATE';
+        return null;
     }
   };
 
@@ -205,6 +205,13 @@ export default class TasksApi extends AccessTasksApi {
     }
 
     const state = this.setState(requiredState);
+
+    if (state === null) {
+      return {
+        error: true,
+        message: `Unable to change status, unknown status "${state}" a task "${taskId}"`,
+      };
+    }
 
     const result = await this.patchResourse(`${this.URL_BASE}/${taskId}`, {
       state,

--- a/src/services/rest-api/tasks-api.js
+++ b/src/services/rest-api/tasks-api.js
@@ -135,7 +135,6 @@ export default class TasksApi extends AccessTasksApi {
     return result;
   }
 
-  // Cannot edit "state", "author" property, "state", "author" property is read-only
   async editTaskHeader({ githubId, taskId = null, data }) {
     if (!taskId) {
       return {
@@ -163,9 +162,6 @@ export default class TasksApi extends AccessTasksApi {
     return result;
   }
 
-  /* 
-    Аргумент requiredState формализован и можем принимать только перечисленные значения,
-  */
   async toggleTaskState({
     githubId,
     taskId = null,


### PR DESCRIPTION
**Модуль для работы с сущностью Reviews**
Основные методы модуля не отличаются от аналогичных модулей API.

Специальные методы:

`getReviewByRequest(requestId)` - выводит все reviews созданные на указанный review request. Требуется передача в аргументе поля requestId, возвращает полные данные в виде массива объектов

`getSelfGradeRequest(requestId)` - выводит объект selfGrade из review request, нужен для копирования самооценки 
selfGrade в оценку grade review.

`getReviewByStateNoDraft()` - вызов метода возвращает список review в статусе DRAFT

`getReviewByStateDraft() `- вызов метода возвращает список review в статусе отличном от DRAFT 
  
`createReview({ githubId, data })` - создание review, аргументы метода передаются объектом!
    СТРУКТУРА объекта в параметре data:
```
 {
      requestId: ...,           // Обязательное поле, ссылка на review request на который создается review 
      author: githubId,    // Обязательное поле, автор review 
      grade: {}                 // Обязательное поле, сюда передается оценка проверяющего, по структуре повторяет самооценку  из review request
 }                                  

```

`editReview({ githubId, reviewId = null, data }) `- редактирование review, редактируются только те поля которые переданы в data, аргументы метода передаются объектом!
Так как все поля заголовка review не подлежат редактированию, то передавать в метод можно только объект grade
    СТРУКТРУРА объекта data:
```
{
      grade: {
        basic_p1: {
          score: 20,                 // Оценка проверяющего
          comment: "text...",         // Комментарий проверяющего
          protest: "text ...",        // Возражения проверяемого, заполняются в статусе диспут
          suggestedScore: 30          // Рекомендуемая оценка проверяемого, заполняются в статусе диспут
        },
        extra_p1: {...},
        fines_p1: {...},
    }         
```

`delReview({ githubId, reviewId = null })` - удаление review , удаляется полностью, аргументы метода передаются объектом!
  


```
toggleReviewState({
    githubId,
    reviewId = null,
    requiredState // enum 
  })
``` 
- переключение статуса review DRAFT, PUBLISHED, ACCEPTED, DISPUTED, REJECTED,

Аргумент requiredState формализован и можем принимать только значения - **DRAFT_TO_PUBLISHED, PUBLISHED_TO_ACCEPTED, PUBLISHED_TO_DISPUTED, DISPUTED_TO_ACCEPTED, ACCEPTED_TO_REJECTED, REJECTED_TO_DISPUTED, REJECTED_TO_ACCEPTED**. 

Последние 5 методов возвращают объект идентичный переданному в случае успеха, или сообщение об ошибке.
Формат сообщения - объект вида {error: true, message: 'text ...'}

Экземпляры сущности **Review** могут находится в статусах DRAFT, PUBLISHED, ACCEPTED, DISPUTED, REJECTED.
В каждом статусе существует свой набор доступных действий пользователя для определенных ролей. 
При осуществлении манипуляций с набором данных проводятся проверки по матрице доступа:

**В статусе CREATE, DRAFT** - пользователь с ролью "student" или "author", или "supervisor" - имеет право создавать и редактировать, удалять и изменить статус DRAFT_TO_PUBLISHED review созданные самим пользователем. 
Исключение: пользователь создавший review request не может создать review на этот  review request.
При создании review проводятся проверки на существование review request на который ссылается review.

**В cтатусе PUBLISHED** доступно изменение статуса:
- PUBLISHED_TO_DISPUTED - только пользователю с ролью "student" - автору review request 
- PUBLISHED_TO_ACCEPTED - авторы review request или review, а также пользователь с ролью "supervisor" и системная учетная запись "systems" (в случае закрытия review request в рамках cross-check-sesson по наступлению события)

**В статусе DISPUTED:**
Редактирование - только авторы review request или review, в рамках обсуждения результатов проверки. Необходимо предусмотреть в компоненте редактирование только соответствующих полей в объекте grade.
Изменение статуса: DISPUTED_TO_ACCEPTED - авторы review request или review,а также пользователь с ролью "supervisor" и системная учетная запись "systems" (в случае закрытия review request в рамках cross-check-sesson по наступлению события)

**В статусе ACCEPTED**: 
Изменение статуса: ACCEPTED_TO_REJECTED - только пользователь с ролью "supervisor"

**В статус REJECTED**:
 Изменение статуса: REJECTED_TO_ACCEPTED и REJECTED_TO_DISPUTED - только пользователь с ролью "supervisor"

**Предполагаемый алгоритм приложения:**

1. Пользователь выбирает review request и создает review.
2. При создании review пользователю доступна для просмотра и копирования самооценка студента (объект selfGrade review request)
3. Ревьювер оценивает приложение, и, или копирует оценки студента без изменений, или проставляет свои с комментариями по пунктам. По умолчанию при создании review статус DRAFT.
4. Когда review готово, ревьювер переводит его в статус PUBLISHED. В этом статусе его может увидеть студент.
4.1. Студент если согласен с оценкой переводит review в статус ACCEPTED (или ничего не делает, предполагается что  review закроет система когда закроется cross-check-sesson по событию). В этом статусе оценки из review участвуют в финальном подсчете.
4.2. Студент не согласен с оценкой и переводит review в статус DISPUTED. В этом статусе студент может добавить свою оценку и комментарий.
4.3. Ревьювер видит возражения студента и, или соглашается с ними и исправляет свою оценку, или не соглашается, оставляет свою оценку и переводит в ACCEPTED.
4.4. Если DISPUTED остается без изменений, то при закрытии  cross-check-sesson по событию система переводит review в статус ACCEPTED с оценками из возражений студента соблюдая принцип: "любые сомнения трактуются в пользу студента" (этот процесс можно не реализовывать, но он предусмотрен текущей матрицей доступа для пользователя с ролью systems).
5. Пользователь с правами supervisor видит все review в статусе отличном от DRAFT. Любое review из статуса ACCEPTED пользователь с правами supervisor может перевести в REJECTED. В этом статусе оценка из review не входит в финальную оценку.
6. При необходимости supervisor может переводить review из статуса REJECTED в статус ACCEPTED для учета оценки в финальном подсчете баллов, и в статус DISPUTED для возврата review на переоценку.


 